### PR TITLE
GH-2: Fix release.toml configuration for semantic releases

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,6 @@
 # Semantic Release Configuration for Agenterra
 # Uses cargo-release for automated semantic versioning
 
-[workspace]
 # Synchronize workspace crate versions
 consolidate-commits = true
 shared-version = true


### PR DESCRIPTION
## Summary
- Fix invalid `[workspace]` section in release.toml that prevents cargo-release execution
- Enable semantic release workflow for customer releases

## Problem
The release.toml configuration had an invalid `[workspace]` section header that cargo-release doesn't recognize, causing semantic release failures.

## Solution
Remove the invalid section header and place all configuration at root level as expected by cargo-release.

## Test plan
- [x] Configuration syntax validated 
- [ ] Semantic release execution confirmed after merge

**Priority: HIGH** - Blocking customer releases

🤖 Generated with [Claude Code](https://claude.ai/code)