### PR TITLE
fix: prevent cargo-release push during CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,5 @@ jobs:
         cargo release config
         # Run a dry-run patch release to validate configuration
         # Use --allow-branch to work with detached HEAD in CI
-        cargo release patch --allow-branch HEAD --no-verify
+        # Use --no-push to prevent pushing during dry-run validation
+        cargo release patch --allow-branch HEAD --no-verify --no-push


### PR DESCRIPTION
## Summary
- Added `--no-push` flag to cargo-release validation in CI workflow
- Fixes Release Configuration job failures caused by push attempts during dry-run

## Problem
The Release Configuration CI job was failing because cargo-release was trying to push changes during the dry-run validation, which fails in the read-only CI environment.

## Solution  
Added `--no-push` flag to the cargo-release command to prevent push attempts while still validating:
- File references in release.toml
- Version replacement patterns
- Release configuration syntax

## Test plan
- [x] CI validation runs without push attempts
- [x] Release Configuration job passes
- [x] All other CI checks continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)