### PR TITLE
fix: restore clean directory validation and fix syntax error

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ if ! command -v cargo-release &> /dev/null; then
     cargo install cargo-release
 fi
 
-Validate current state
+# Validate current state
 echo -e "${YELLOW}🔍 Validating repository state...${NC}"
 if [[ -n $(git status --porcelain) ]]; then
     echo -e "${RED}❌ Working directory is not clean. Please commit or stash changes.${NC}"


### PR DESCRIPTION
## Summary
- Fix missing `#` comment on line 24 that caused `Validate: command not found` error
- Restore proper clean directory validation (safety feature)
- Script now executes correctly with all safety checks enabled

## Problem
The release script was failing with syntax error due to missing comment character on line 24.

## Solution
- Add missing `#` to properly comment the line
- Keep clean directory validation enabled (good safety practice)

## Test Plan
- [ ] CI passes on this PR
- [ ] Merge to main
- [ ] Run `./scripts/release.sh minor` from clean main branch
- [ ] Verify script executes without syntax errors

🚀 Generated with [Claude Code](https://claude.ai/code)