### PR TITLE
fix: simplify release workflow and remove agnt binary alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,8 @@ run-name: ${{ startsWith(github.ref,'refs/tags/') && format('ðŸš€ Release {0} ðŸ
 
 on:
   push:
-    # Run PR update job on any branch push; release job gated by tags
-    branches: ["**"]
-    tags: ["v*.*.*"]
+    branches: [main]  # Only run on main branch pushes
+    tags: ["v*.*.*"]   # And tag pushes
 
 permissions:
   contents: write     # commit changelog & Cargo.toml bumps
@@ -16,37 +15,13 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  release-plz-release:
-    name: Release-plz release
-    # Run only when a version tag (vX.Y.Z) is pushed
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Run release-plz (release)
-        uses: release-plz/action@v0.5.107
-        with:
-          command: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   release-plz-pr:
     name: Release-plz PR
-    if: startsWith(github.ref, 'refs/heads/')
+    if: github.ref == 'refs/heads/main'  # Only on main branch
     runs-on: ubuntu-latest
     concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
+      group: release-plz-pr
+      cancel-in-progress: true  # Cancel previous runs on new pushes
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -66,9 +41,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  release:
+    name: Publish & Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [release-plz-pr]  # Ensure Release PR was created first
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Publish crates
+        run: |
+          cd crates/agenterra-cli
+          cargo publish --no-verify  # --no-verify since we built in PR
+
   build:
-    name: Build binaries
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    name: Build ${{ matrix.target }}
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: release  # Wait for publish
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -76,71 +74,78 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            binary_name: agenterra
             asset_name: agenterra-linux-x86_64.tar.gz
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            binary_name: agenterra
             asset_name: agenterra-linux-aarch64.tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
-            binary_name: agenterra
             asset_name: agenterra-macos-x86_64.tar.gz
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary_name: agenterra
             asset_name: agenterra-macos-aarch64.tar.gz
 
     steps:
-    - name: Checkout sources
-      uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        key: ${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Install cross-compilation tools (Linux ARM64)
-      if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Install cross-compilation tools (Linux ARM64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
-    - name: Configure cross-compilation (Linux ARM64)
-      if: matrix.target == 'aarch64-unknown-linux-gnu'
-      run: |
-        mkdir -p ~/.cargo
-        echo "[target.aarch64-unknown-linux-gnu]" >> ~/.cargo/config.toml
-        echo "linker = \"aarch64-linux-gnu-gcc\"" >> ~/.cargo/config.toml
+      - name: Build release binary
+        run: |
+          cargo build --release --target ${{ matrix.target }} --bin agenterra
 
-    - name: Build binaries
-      run: |
-        cargo build --release --target ${{ matrix.target }} --bin agenterra
-        cargo build --release --target ${{ matrix.target }} --bin agnt
+      - name: Strip binary (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          strip target/${{ matrix.target }}/release/agenterra
 
-    - name: Strip binaries (Linux/macOS)
-      if: runner.os != 'Windows'
-      run: |
-        strip target/${{ matrix.target }}/release/${{ matrix.binary_name }}
-        strip target/${{ matrix.target }}/release/agnt
+      - name: Create release assets
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.asset_name }} agenterra
+          cd - >/dev/null
+          shasum -a 256 ${{ matrix.asset_name }} > ${{ matrix.asset_name }}.sha256
 
-    - name: Create archive
-      run: |
-        cd target/${{ matrix.target }}/release
-        tar czf ../../../${{ matrix.asset_name }} ${{ matrix.binary_name }} agnt
-        cd -
+      - name: Get release upload URL
+        id: get_release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: process.env.GITHUB_REF.replace('refs/tags/', '')
+            });
+            return release.upload_url;
 
-    - name: Generate checksums
-      run: |
-        sha256sum ${{ matrix.asset_name }} >> checksums-${{ matrix.target }}.txt
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.get_release.outputs.result }}
+          asset_path: ${{ matrix.asset_name }}
+          asset_name: ${{ matrix.asset_name }}
+          asset_content_type: application/gzip
 
-    - name: Upload Release Assets
-      run: |
-        gh release upload ${{ github.ref_name }} ${{ matrix.asset_name }} checksums-${{ matrix.target }}.txt
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload checksum
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.get_release.outputs.result }}
+          asset_path: ${{ matrix.asset_name }}.sha256
+          asset_name: ${{ matrix.asset_name }}.sha256
+          asset_content_type: text/plain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ Triggered by version tags (v*.*.*) or manual workflow dispatch:
 - x86_64-apple-darwin (macOS Intel)
 - aarch64-apple-darwin (macOS ARM64)
 - Cross-compilation setup for ARM64 targets
-- Build both `agenterra` and `agnt` binaries
+- Build the `agenterra` binary
 - Strip binaries for smaller size
 - Create platform-specific archives (tar.gz)
 - Generate SHA256 checksums

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cargo run -p agenterra -- scaffold --schema-path ./tests/fixtures/openapi/petsto
 # Generate from a remote URL without install:
 cargo run -p agenterra -- scaffold --schema-path https://petstore3.swagger.io/api/v3/openapi.json --output .agenterra/cargo_run_petstore_mcp_server_remote_url
 
-# Or install the CLI (also provides 'agnt' as a short alias)
+# Or install the CLI
 cargo install --path crates/agenterra-cli
 
 # Generate your MCP server from a local file

--- a/crates/agenterra-cli/Cargo.toml
+++ b/crates/agenterra-cli/Cargo.toml
@@ -23,9 +23,5 @@ tempfile = "3.10"
 name = "agenterra"
 path = "src/main.rs"
 
-[[bin]]
-name = "agnt"
-path = "src/main.rs"
-
 [dev-dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
## Summary
- Restructure release workflow to separate PR creation from publishing
- Add concurrency controls to prevent duplicate PR runs  
- Remove agnt binary alias - keep only agenterra
- Fix release asset upload to use proper GitHub actions
- Add proper dependencies between workflow jobs
- Update docs to reflect single binary name

## Changes
- Reorganized `.github/workflows/release.yml` to have clearer job separation
- Removed `agnt` binary configuration from `Cargo.toml`
- Updated README and CLAUDE.md documentation

## Test plan
- [x] Verify workflow syntax is valid
- [x] CI checks will validate the changes
- [ ] Release workflow will be tested on next tag push

Related to #2

🤖 Generated with [Claude Code](https://claude.ai/code)