### PR TITLE
fix: split release workflows to prevent circular dependencies

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,41 @@
+name: Release PR Update
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write     # commit changelog & Cargo.toml bumps
+  pull-requests: write
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release-plz-pr:
+    name: Release-plz PR
+    # Skip commits coming from the bot itself to avoid loops
+    if: github.actor != 'release-plz[bot]'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-pr
+      cancel-in-progress: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run release-plz (PR)
+        uses: release-plz/action@v0.5.107
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ run-name: ${{ startsWith(github.ref,'refs/tags/') && format('ğŸš€ Release {0} ğŸ
 
 on:
   push:
-    branches: [main]  # Only run on main branch pushes
-    tags: ["v*.*.*"]   # And tag pushes
+    tags: ["v*.*.*"]   # Run only on tag pushes
 
 permissions:
   contents: write     # commit changelog & Cargo.toml bumps
@@ -47,7 +46,6 @@ jobs:
   release:
     name: Publish & Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [release-plz-pr]  # Ensure Release PR was created first
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Summary
Split the release workflow into two separate workflows to fix the circular dependency issue that was preventing releases from running.

## Changes
- **New `release-pr.yml`**: Handles release PR creation on main branch pushes
- **Updated `release.yml`**: Now only handles tag-triggered publishing and builds
- Removed `needs: [release-plz-pr]` dependency that was causing jobs to be skipped

## How it works now
1. Push to main → `release-pr.yml` creates/updates the Release PR
2. Merge Release PR → release-plz creates tag `vX.Y.Z`
3. Tag push → `release.yml` publishes crates and builds binaries

## Test plan
- [x] Verify both workflow files have valid syntax
- [ ] After merge, confirm release PR creation still works
- [ ] Confirm tag pushes trigger actual releases

Closes #2 (hopefully for real this time\! 🤞)

🤖 Generated with [Claude Code](https://claude.ai/code)