### PR TITLE
fix: improve workflow names and run names for clarity

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,4 +1,5 @@
-name: Release PR Update
+name: Release-plz PR Update
+run-name: "🚀 Release-plz PR Update (main)"
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-name: Release
-run-name: ${{ startsWith(github.ref,'refs/tags/') && format('🚀 Release {0} 🤖', github.ref_name) || '🚀 Release PR Update 🤖' }}
+name: Publish & Release
+run-name: ${{ format('🚀 Publish & Release {0}', github.ref_name) }}
 
 on:
   push:


### PR DESCRIPTION
## Summary
Clean up workflow names and run names for better clarity in the GitHub Actions UI.

## Changes
- **release-pr.yml**: 
  - Workflow name: "Release-plz PR Update"
  - Run name: "🚀 Release-plz PR Update (main)"
- **release.yml**:
  - Workflow name: "Publish & Release"  
  - Run name: "🚀 Publish & Release {version}"
  - Removed conditional logic since this only runs on tags

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Check that workflow names display correctly in Actions tab

Related to #2

🤖 Generated with [Claude Code](https://claude.ai/code)