### PR TITLE
fix: replace cargo publish with GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,12 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Publish crates
-        run: |
-          cd crates/agenterra-cli
-          cargo publish --no-verify  # --no-verify since we built in PR
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
 
   build:
     name: Build ${{ matrix.target }}


### PR DESCRIPTION
## Summary
Replace the manual cargo publish step with automated GitHub release creation.

## Changes
- Removed `cargo publish` command from release workflow
- Added `softprops/action-gh-release@v2` to create GitHub releases
- Release is created automatically when tags are pushed
- Binary assets will be attached by subsequent build jobs

## Benefits
- Simplifies the release process
- Ensures GitHub release exists before binaries are built
- Eliminates potential publish failures

## Test plan
- [x] Verify workflow syntax is valid
- [ ] On next tag push, confirm GitHub release is created
- [ ] Confirm binary assets attach correctly to the release

Related to #2

🤖 Generated with [Claude Code](https://claude.ai/code)