### PR TITLE
ci: fix release upload URL (#2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
               repo: context.repo.repo,
               tag: process.env.GITHUB_REF.replace('refs/tags/', '')
             });
-            return release.upload_url;
+            return release.upload_url.replace('{?name,label}', '');
 
       - name: Upload release assets
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
### Fix
Strip  from release.upload_url before passing to actions/upload-release-asset, preventing ECONNRESET failures during asset uploads.

This unblocks the automated release pipeline so future version tags publish binaries successfully.

Closes #2.