### PR TITLE
fix: disable crates.io publish in release-plz (#2)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,6 +7,7 @@ publish = false
 # Per-package overrides (optional)
 [[package]]
 name = "agenterra"
+release = false
 
 [[package]]
 name = "agenterra-core"


### PR DESCRIPTION
### Fix\nSet  for the `agenterra` crate so release-plz no longer attempts a crates.io diff.\nThis prevents the "package not found in registry" error during tag releases and re-enables fully automated GitHub Releases.\n\nCloses #2.