### PR TITLE
fix: correct release-plz config (skip crates.io diff) (#2)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,13 +2,13 @@
 changelog_update = true
 git_release_enable = true
 features_always_increment_minor = false
-publish = false
 
-# Per-package overrides (optional)
 [[package]]
 name = "agenterra"
-release = false
+release = true
+publish = false
 
 [[package]]
 name = "agenterra-core"
-release = false
+release = true
+publish = false


### PR DESCRIPTION
### Fix

* Remove workspace-level `publish=false` (not required)
* Set `release=true`, `publish=false` per crate so release-plz tags but skips crates.io.
* Ensure Cargo.toml remains public to release-plz.

This should finally allow the Release PR workflow to generate tags without registry errors.

Maybe Closes #2?????