### PR TITLE
fix: update release workflow to support both tag patterns (#60)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ run-name: ${{ format('🚀 Publish & Release {0}', github.ref_name) }}
 
 on:
   push:
-    tags: ["v*.*.*"]   # Run only on tag pushes
+    tags:
+      - "v*.*.*"          # workspace-level tag (legacy)
+      - "*-v*.*.*"        # per-crate tags, e.g. agenterra-core-v0.2.0
 
 permissions:
   contents: write     # commit changelog & Cargo.toml bumps


### PR DESCRIPTION
## Summary
- Fixes release-plz automation failure where it couldn't detect conventional commits
- Updates workflow to support both simple tags (v0.1.0) and per-crate tags (agenterra-core-v0.1.0)
- Maintains backwards compatibility while fixing tag pattern mismatch

## Test plan
- [ ] Merge PR to deploy fixed workflow
- [ ] Push missing per-crate tags to trigger release-plz
- [ ] Verify release-plz creates release PR automatically

🤖 Generated with [Claude Code](https://claude.ai/code)