### PR TITLE
fix: standardize cache keys in release workflow to match CI (#60)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          key: Linux-stable
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -73,7 +75,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-${{ matrix.target }}
 
       - name: Install musl-related tools
         if: contains(matrix.target, 'musl')


### PR DESCRIPTION
## Summary
- Fixes cache key inconsistencies causing release workflow failures
- Standardizes cache keys to match CI workflow pattern (simple matrix-based keys)
- Removes overly complex cache keys that were hitting GitHub limits

## Changes
- Release job: Uses `Linux-stable` key to match CI pattern
- Build jobs: Uses `${{ matrix.os }}-${{ matrix.target }}` instead of complex hash-based keys

## Test plan
- [ ] Merge PR to deploy fixed cache configuration
- [ ] Re-run release workflow to verify cache functionality

🤖 Generated with [Claude Code](https://claude.ai/code)