### PR TITLE
fix: standardize cache keys in release workflow to match CI (#60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.os }}-${{ matrix.rust }}
+        key: ${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+        cache-on-failure: true
 
     - name: Run cargo check
       run: cargo check --all-targets --all-features
@@ -80,6 +81,9 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+        cache-on-failure: true
 
     - name: Run cargo fmt
       run: cargo fmt --all -- --check
@@ -99,6 +103,9 @@ jobs:
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+        cache-on-failure: true
 
     - name: Install cargo-audit
       run: cargo install cargo-audit

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-releasepr-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
 
       - name: Run release-plz (PR)
         uses: release-plz/action@v0.5.107

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-releasepr-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
           cache-on-failure: true
 
       - name: Run release-plz (PR)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: Linux-stable-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-stable-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -76,6 +77,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
 
       - name: Install musl-related tools
         if: contains(matrix.target, 'musl')


### PR DESCRIPTION
## Summary
- Standardize cache key format across all workflows to fix cache restoration issues
- Add `cache-on-failure: true` to persist caches even when jobs fail
- Resolve "Cache not found" loop that was preventing release-plz from working

## Test plan
- [x] Run pre-commit checks (cargo fmt, clippy, test)
- [x] Verify cache persistence in CI workflows
- [x] Confirm release-plz can now detect conventional commits
- [x] Check that cache keys are correctly generated with Cargo.lock hash

This PR addresses the cache persistence issues identified in #60 where workflow failures were preventing caches from being saved, leading to a continuous loop of cache misses.

Co-authored-by: ChatGPT o3 <noreply@openai.com>

🤖 Generated with [Claude Code](https://claude.ai/code)