### PR TITLE
🚨 HOTFIX: Remove non-existent agenterra-cli from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,11 +9,6 @@ release = true
 publish = false
 
 [[package]]
-name = "agenterra-cli"
-release = false
-publish = false
-
-[[package]]
 name = "agenterra-client"
 release = false
 publish = false


### PR DESCRIPTION
## 🚨 Critical Hotfix - Part 2

**Fixes:** Issue #68 - CI/CD pipeline still failing after first fix

## Problem
After the first fix was merged, release-plz is now failing with a different error:
```
The following overrides are not present in the workspace: `agenterra-cli`
```

## Root Cause
The crate located in `crates/agenterra-cli/` is actually named `"agenterra"` in its Cargo.toml, not `"agenterra-cli"`. 

## Solution
Removed the non-existent `agenterra-cli` entry from release-plz.toml.

## Testing
- ✅ Verified crate names match Cargo.toml files
- ✅ Only 3 library crates exist: agenterra-client, agenterra-core, agenterra-mcp
- ✅ Main app "agenterra" is the only release target

## Priority
**CRITICAL** - CI/CD is still broken and blocking all processes.

🤖 Generated with [Claude Code](https://claude.ai/code)