### PR TITLE
fix: sync version number to match latest release (#68)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "agenterra"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agenterra-core",
  "agenterra-mcp",

--- a/crates/agenterra-cli/Cargo.toml
+++ b/crates/agenterra-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenterra"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "CLI for generating MCP servers from OpenAPI specs with Agenterra"
 license = "MIT"


### PR DESCRIPTION
## Fix Version Synchronization Issue

**Part of:** Issue #68 - CI/CD pipeline fixes

## Problem
Release-plz was trying to release version 0.1.0, but that version was already released (we have git tag `agenterra-v0.1.1`). This version mismatch was preventing release-plz from properly incrementing versions.

## Root Cause
The Cargo.toml files were never updated after the 0.1.1 release, so they still showed `version = "0.1.0"` while the git tags showed 0.1.1 was already released.

## Solution
Updated the agenterra crate version in Cargo.toml from 0.1.0 to 0.1.1 to match the latest git tag.

## Expected Result
After this fix, release-plz should:
1. Recognize that 0.1.1 is the current version
2. Properly increment to 0.1.2 for the next release
3. Update Cargo.toml files with new versions going forward

## Note
We should also close the stale PR #71 that's trying to release 0.1.0, as it's no longer needed.

🤖 Generated with [Claude Code](https://claude.ai/code)