### PR TITLE
fix: remove test project patterns from gitignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
-        cache-on-failure: true
+        key: ${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock', '.gitignore') }}
 
     - name: Run cargo check
       run: cargo check --all-targets --all-features
@@ -84,8 +83,7 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-        cache-on-failure: true
+        key: ${{ github.job }}-${{ hashFiles('**/Cargo.lock', '.gitignore') }}
 
     - name: Run cargo fmt
       run: cargo fmt --all -- --check
@@ -107,8 +105,7 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
-        cache-on-failure: true
+        key: ${{ github.job }}-${{ hashFiles('**/Cargo.lock', '.gitignore') }}
 
     - name: Install cargo-audit
       run: cargo install cargo-audit

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
-          cache-on-failure: true
+          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock', '.gitignore') }}
 
       - name: Run release-plz release
         uses: release-plz/action@v0.5.107
@@ -59,8 +58,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
-          cache-on-failure: true
+          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock', '.gitignore') }}
 
       - name: Run release-plz PR
         uses: release-plz/action@v0.5.107

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 **/.DS_Store
 
 /target
-
-# Test project patterns (created in workspace root during dev)
-test_*/
-*_test/
-*_test_project/

--- a/tests/e2e_mcp_test.rs
+++ b/tests/e2e_mcp_test.rs
@@ -13,6 +13,8 @@ use tokio::process::Command as AsyncCommand;
 use tokio::time::timeout;
 use tracing::{debug, error, info, warn};
 
+const CLI_FLAG_TESTS_SANDBOX_DIR: &str = "target/tmp/cli_flag_tests";
+
 /// Clean up any SQLite database files for a given project name
 /// This ensures each test run starts with a fresh database state
 fn cleanup_project_databases(project_name: &str) -> Result<()> {
@@ -604,7 +606,9 @@ fn test_cli_help_output() {
     let agenterra = env!("CARGO_BIN_EXE_agenterra");
     let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // Use sandbox directory under target/tmp to avoid polluting repo root
-    let sandbox_dir = project_dir.join("target/tmp/cli_flag_tests");
+    let sandbox_dir = project_dir
+        .join(CLI_FLAG_TESTS_SANDBOX_DIR)
+        .join("test_cli_help_output");
     let _ = std::fs::remove_dir_all(&sandbox_dir);
     std::fs::create_dir_all(&sandbox_dir).unwrap();
 
@@ -636,7 +640,9 @@ fn test_new_cli_structure() {
     let agenterra = env!("CARGO_BIN_EXE_agenterra");
     let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // Use sandbox directory under target/tmp to avoid polluting repo root
-    let sandbox_dir = project_dir.join("target/tmp/cli_flag_tests");
+    let sandbox_dir = project_dir
+        .join(CLI_FLAG_TESTS_SANDBOX_DIR)
+        .join("test_new_cli_structure");
     let _ = std::fs::remove_dir_all(&sandbox_dir);
     std::fs::create_dir_all(&sandbox_dir).unwrap();
 
@@ -671,7 +677,9 @@ fn test_cli_flag_combinations() -> Result<()> {
     let agenterra = env!("CARGO_BIN_EXE_agenterra");
     let project_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     // Use sandbox directory under target/tmp to avoid polluting repo root
-    let sandbox_dir = project_dir.join("target/tmp/cli_flag_tests");
+    let sandbox_dir = project_dir
+        .join(CLI_FLAG_TESTS_SANDBOX_DIR)
+        .join("test_cli_flag_combinations");
     let _ = std::fs::remove_dir_all(&sandbox_dir);
     std::fs::create_dir_all(&sandbox_dir).unwrap();
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Fixes a broken build. No ticket created. Hot Fix for issue #89 release

## Description

Removed the `test` items from .gitignore so the legitimate `rmcp` tests would not class with the release builds