### PR TITLE
fix: correct GitHub actor name for release-plz bot exclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
-    if: github.actor != 'release-plz[bot]'
+    if: github.actor != 'github-actions[bot]'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -70,7 +70,7 @@ jobs:
   lint:
     name: Linting
     runs-on: ubuntu-latest
-    if: github.actor != 'release-plz[bot]'
+    if: github.actor != 'github-actions[bot]'
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
@@ -94,7 +94,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
-    if: github.actor != 'release-plz[bot]'
+    if: github.actor != 'github-actions[bot]'
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The CI workflow was checking for 'release-plz[bot]' but release-plz actually runs as 'github-actions[bot]'. This was causing required CI checks to block release-plz PRs.

## Changes
- Updated all CI job conditions from  to 

This allows release-plz automated PRs to skip CI checks while still requiring them for all other PRs.